### PR TITLE
Enhance JSON Path Retrieval Function to Support Flexible Notation

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -215,7 +215,8 @@ function getCurrentEventObject() {
 }
 
 function getValueByPath(obj, path) {
-  const parts = path.split('.');
+  const sanitizedPath = path.split('[').join('.').split(']').join('');
+  const parts = sanitizedPath.split(".").filter(x => x.length); 
   let current = obj;
   for (let i = 0; i < parts.length; i++) {
     if (getType(current) == 'array') {


### PR DESCRIPTION
This pull request introduces enhancements to the existing JSON path retrieval function, allowing it to support multiple notations for accessing values within nested JSON objects.

## Changes Made:
- The function can now handle paths specified in different formats, including:
  - Dot notation: `user.addresses.0.city`
  - Bracketed notation: `user.addresses.[0].city`
  - Mixed notation: `user.addresses[0].city`
  
- This update ensures backward compatibility, meaning that the previous path format remains valid and functional.
